### PR TITLE
Added baked in nil value

### DIFF
--- a/pyra.rb
+++ b/pyra.rb
@@ -68,7 +68,7 @@ def triangle_from(lines, ptr_inds = nil)
     }
 end
 
-$vars = {"eps" => ""}
+$vars = {"eps" => "", "nil" => nil}
 $UNDEF = :UNDEF
 
 def parse(str)


### PR DESCRIPTION
At the beginning of the execution, the dictionary of variables `$vars` starts with a key-value pair  `"eps" => ""`. I've also added a `"nil" => nil` to allow one to use in in comparisons, as opposed to having to create the `nil` value first.

An example usage would be this scheme, which returns true is it got a command line input, and 0 otherwise.

```
      ^              ^
     / \            / \
    /   \          /out\
   / set \        ^-----
  ^-------^      /!\
 / \     / \    ^---
/nil\   /arg\  / \
-----  ^----- / = \
      / \    ^-----^
     /999\  / \   / \
     ----- /arg\ /nil\
          ^----- -----
         /1\
         ---
```

Making `nil` in this manner is a bit dodgy (although I don't realistically expect anyone to ever break it by passing more than 999 input arguments...). With the change, the following would suffice:

```
            ^
           / \
          /out\
         ^-----
        /!\
       ^---
      / \
     / = \
    ^-----^
   / \   / \
  /arg\ /nil\
 ^----- -----
/1\
---
```